### PR TITLE
Changed generator function to gfun / consumer function to cfun / func…

### DIFF
--- a/Repl/examples/bankaccount.ub
+++ b/Repl/examples/bankaccount.ub
@@ -10,31 +10,31 @@ codata BankAccount where
   Balance() : Nat
   Withdraw(Nat) : BankAccount
 
-function ifThenElse(b : Bool, t : BankAccount, e : BankAccount) : BankAccount :=
+fun ifThenElse(b : Bool, t : BankAccount, e : BankAccount) : BankAccount :=
   match Bool:Ite b using x := t : BankAccount , y := e : BankAccount returning BankAccount with
     case True() => x
     case False() => y
 
-consumer function Nat:BalanceAfterNWithdrawals(ba : BankAccount, amount : Nat) : Nat :=
+cfun Nat:BalanceAfterNWithdrawals(ba : BankAccount, amount : Nat) : Nat :=
   case Zero() => ba.Balance()
   case Succ(y) => let next := ba.Withdraw(amount)
                   in y.BalanceAfterNWithdrawals(next, amount)
 
-consumer function Nat:Plus(x : Nat) : Nat :=
+cfun Nat:Plus(x : Nat) : Nat :=
   case Zero() => x
   case Succ(y) => Succ(y.Plus(x))
 
-consumer function Nat:Minus(x : Nat) : Nat :=
+cfun Nat:Minus(x : Nat) : Nat :=
   case Zero() => Zero()
   case Succ(y) => match Nat:MinusHelper x using z := y : Nat returning Nat with
                     case Zero() => Succ(z)
                     case Succ(v) => z.Minus(v)
 
-consumer function Nat:IsZero() : Bool :=
+cfun Nat:IsZero() : Bool :=
   case Zero() => True()
   case Succ(x) => False()
 
-consumer function Nat:LessThan(x : Nat) : Bool :=
+cfun Nat:LessThan(x : Nat) : Bool :=
   case Zero() => match Nat:LessThanZero x returning Bool with
                     case Zero() => False ()
                     case Succ(y) => True ()
@@ -43,11 +43,11 @@ consumer function Nat:LessThan(x : Nat) : Bool :=
  		    case Succ(z) => z.LessThan(y)
 
 
-generator function RegularAccount(bal : Nat) : BankAccount :=
+gfun RegularAccount(bal : Nat) : BankAccount :=
   cocase Balance() => bal
   cocase Withdraw(n) => ifThenElse(bal.LessThan(n), RegularAccount(bal), RegularAccount(bal.Minus(n)))
 
-generator function StatefullAccount(bal : Nat) : BankAccount :=
+gfun StatefullAccount(bal : Nat) : BankAccount :=
   cocase Balance() => bal
   cocase Withdraw(n) => comatch BankAccount:OddStatefullAccount using b := bal : Nat with
                          cocase Balance() => b

--- a/Repl/examples/extended-example-1.ub
+++ b/Repl/examples/extended-example-1.ub
@@ -26,13 +26,13 @@ data Found where
 codata Value2Found where
        Apply(Value) : Found
 
-consumer function Expr:SearchNeg(ctx : Value2Found) : Found :=
+cfun Expr:SearchNeg(ctx : Value2Found) : Found :=
 	 case EVar(n)     => ctx.Apply(ValNegVar(n))
 	 case ENot(e)     => FoundRedex(RedNot(e))
 	 case EAnd(e1,e2) => FoundRedex(RedAnd(e1,e2))
 	 case EOr(e1,e2)  => FoundRedex(RedOr(e1,e2))
 
-consumer function Expr:SearchPos(ctx : Value2Found) : Found :=
+cfun Expr:SearchPos(ctx : Value2Found) : Found :=
 	 case EVar(n)     => ctx.Apply(ValPosVar(n))
 	 case ENot(e)     => e.SearchNeg(ctx)
 	 case EAnd(e1,e2) => e1.SearchPos( comatch Value2Found:AndCtx1 using e2 := e2 : Expr, ctx := ctx : Value2Found  with
@@ -46,7 +46,7 @@ consumer function Expr:SearchPos(ctx : Value2Found) : Found :=
                                                                                        )
                                           )
 
-function search(e : Expr) : Found :=
+fun search(e : Expr) : Found :=
   e.SearchPos(comatch Value2Found:EmptyCtx with
                     cocase Apply(val) => FoundValue(val)
   )

--- a/Repl/examples/extended-example-2.ub
+++ b/Repl/examples/extended-example-2.ub
@@ -30,23 +30,23 @@ data Value2Found where
    _OrCtx1(Expr , Value2Found)
    _OrCtx4(Value , Value2Found)
 
-function search(e : Expr) : Found :=
+fun search(e : Expr) : Found :=
    e.SearchPos(_EmptyCtx())
 
-consumer function Value2Found:Apply(v : Value) : Found :=
+cfun Value2Found:Apply(v : Value) : Found :=
    case _EmptyCtx()      => FoundValue(v)
    case _AndCtx1(e,ctx)  => e.SearchPos(_AndCtx2(v,ctx))
    case _AndCtx2(v2,ctx) => ctx.Apply(ValAnd(v, v2))
    case _OrCtx1(e,ctx)   => e.SearchPos(_OrCtx4(v,ctx))
    case _OrCtx4(v2,ctx)  => ctx.Apply(ValOr(v,v2))
 
-consumer function Expr:SearchPos(ctx : Value2Found) : Found :=
+cfun Expr:SearchPos(ctx : Value2Found) : Found :=
    case EVar(id)    => ctx.Apply(ValPosVar(id))
    case ENot(e)     => e.SearchNeg(ctx)
    case EAnd(e1,e2) => e1.SearchPos(_AndCtx1(e2, ctx))
    case EOr(e1,e2)  => e1.SearchPos(_OrCtx1(e2 , ctx))
 
-consumer function Expr:SearchNeg(ctx : Value2Found) : Found :=
+cfun Expr:SearchNeg(ctx : Value2Found) : Found :=
    case EVar(id) => ctx.Apply(ValNegVar(id))
    case ENot(e) => FoundRedex(RedNot(e))
    case EAnd(e1,e2) => FoundRedex(RedAnd(e1, e2))

--- a/Repl/examples/extended-example-3.ub
+++ b/Repl/examples/extended-example-3.ub
@@ -30,23 +30,23 @@ data Value2Found where
    _OrCtx1(Expr , Value2Found)
    _OrCtx4(Value , Value2Found)
 
-function search(e : Expr) : Found :=
+fun search(e : Expr) : Found :=
    e.SearchPos(_EmptyCtx())
 
-consumer function Value2Found:Apply(v : Value) : Found :=
+cfun Value2Found:Apply(v : Value) : Found :=
    case _EmptyCtx()      => FoundValue(v)
    case _AndCtx1(e,ctx)  => e.SearchPos(_AndCtx2(v,ctx))
    case _AndCtx2(v2,ctx) => ctx.Apply(ValAnd(v, v2))
    case _OrCtx1(e,ctx)   => e.SearchPos(_OrCtx4(v,ctx))
    case _OrCtx4(v2,ctx)  => ctx.Apply(ValOr(v,v2))
 
-consumer function Expr:SearchPos(ctx : Value2Found) : Found :=
+cfun Expr:SearchPos(ctx : Value2Found) : Found :=
    case EVar(id)    => ctx.Apply(ValPosVar(id))
    case ENot(e)     => e.SearchNeg(ctx)
    case EAnd(e1,e2) => e1.SearchPos(_AndCtx1(e2, ctx))
    case EOr(e1,e2)  => e1.SearchPos(_OrCtx1(e2 , ctx))
 
-consumer function Expr:SearchNeg(ctx : Value2Found) : Found :=
+cfun Expr:SearchNeg(ctx : Value2Found) : Found :=
    case EVar(id) => ctx.Apply(ValNegVar(id))
    case ENot(e) => FoundRedex(RedNot(e), ctx)
    case EAnd(e1,e2) => FoundRedex(RedAnd(e1, e2), ctx)

--- a/Repl/examples/extended-example-4.ub
+++ b/Repl/examples/extended-example-4.ub
@@ -30,35 +30,35 @@ data Value2Found where
    _OrCtx1(Expr , Value2Found)
    _OrCtx4(Value , Value2Found)
 
-function search(e : Expr) : Found :=
+fun search(e : Expr) : Found :=
    e.SearchPos(_EmptyCtx())
 
-consumer function Value2Found:Apply(v : Value) : Found :=
+cfun Value2Found:Apply(v : Value) : Found :=
    case _EmptyCtx()      => FoundValue(v)
    case _AndCtx1(e,ctx)  => e.SearchPos(_AndCtx2(v,ctx))
    case _AndCtx2(v2,ctx) => ctx.Apply(ValAnd(v, v2))
    case _OrCtx1(e,ctx)   => e.SearchPos(_OrCtx4(v,ctx))
    case _OrCtx4(v2,ctx)  => ctx.Apply(ValOr(v,v2))
 
-consumer function Expr:SearchPos(ctx : Value2Found) : Found :=
+cfun Expr:SearchPos(ctx : Value2Found) : Found :=
    case EVar(id)    => ctx.Apply(ValPosVar(id))
    case ENot(e)     => e.SearchNeg(ctx)
    case EAnd(e1,e2) => e1.SearchPos(_AndCtx1(e2, ctx))
    case EOr(e1,e2)  => e1.SearchPos(_OrCtx1(e2 , ctx))
 
-consumer function Expr:SearchNeg(ctx : Value2Found) : Found :=
+cfun Expr:SearchNeg(ctx : Value2Found) : Found :=
    case EVar(id) => ctx.Apply(ValNegVar(id))
    case ENot(e) => FoundRedex(RedNot(e), ctx)
    case EAnd(e1,e2) => FoundRedex(RedAnd(e1, e2), ctx)
    case EOr(e1,e2) => FoundRedex(RedOr(e1, e2), ctx)
 
-consumer function Value:AsExpr() : Expr :=
+cfun Value:AsExpr() : Expr :=
    case ValPosVar(id) => EVar(id)
    case ValNegVar(id) => ENot(EVar(id))
    case ValAnd(v1,v2) => EAnd(v1.AsExpr(), v2.AsExpr())
    case ValOr(v1,v2)  => EOr(v1.AsExpr(), v2.AsExpr())
 
-consumer function Value2Found:Combine(e : Expr) : Expr :=
+cfun Value2Found:Combine(e : Expr) : Expr :=
    case _EmptyCtx() => e
    case _AndCtx1(e2, ctx) => EAnd(ctx.Combine(e), e2)
    case _AndCtx2(v, ctx)  => EAnd(v.AsExpr(), ctx.Combine(e))

--- a/Repl/examples/extended-example-5.ub
+++ b/Repl/examples/extended-example-5.ub
@@ -27,13 +27,13 @@ codata Value2Found where
    Apply(Value) : Found
    Combine(Expr) : Expr
 
-function search(e : Expr) : Found :=
+fun search(e : Expr) : Found :=
  e.SearchPos( comatch Value2Found:EmptyCtx  with
                  cocase Apply(v) => FoundValue(v)
                  cocase Combine(e) => e
             )
 
-consumer function Expr:SearchPos(ctx : Value2Found) : Found :=
+cfun Expr:SearchPos(ctx : Value2Found) : Found :=
    case EVar(id) => ctx.Apply(ValPosVar(id))
    case ENot(e) => e.SearchNeg(ctx)
    case EAnd(e1,e2) => e1.SearchPos( comatch Value2Found:AndCtx1 using e2 := e2 : Expr , ctx := ctx : Value2Found with
@@ -51,13 +51,13 @@ consumer function Expr:SearchPos(ctx : Value2Found) : Found :=
                                               cocase Combine(ex) => EOr(ctx.Combine(ex) , e2)
 			          )
 
-consumer function Expr:SearchNeg(ctx : Value2Found) : Found :=
+cfun Expr:SearchNeg(ctx : Value2Found) : Found :=
    case EVar(id)    => ctx.Apply(ValNegVar(id))
    case ENot(e)     => FoundRedex(RedNot(e) , ctx)
    case EAnd(e1,e2) => FoundRedex(RedAnd(e1, e2) , ctx)
    case EOr(e1,e2)  => FoundRedex(RedOr(e1, e2) , ctx)
 
-consumer function Value:AsExpr() : Expr :=
+cfun Value:AsExpr() : Expr :=
    case ValPosVar(id) => EVar(id)
    case ValNegVar(id) => ENot(EVar(id))
    case ValAnd(v1,v2) => EAnd(v1.AsExpr() , v2.AsExpr())

--- a/Repl/examples/int_to_int.ub
+++ b/Repl/examples/int_to_int.ub
@@ -11,26 +11,26 @@ data Nat2Nat where
   Plus(Nat)
   Mult(Nat)
 
-consumer function Nat:PlusFun(y : Nat) : Nat :=
+cfun Nat:PlusFun(y : Nat) : Nat :=
   case Zero()  => y
   case Succ(x) => Succ( x.PlusFun(y) )
 
-consumer function Nat:MultFun(y : Nat) : Nat :=
+cfun Nat:MultFun(y : Nat) : Nat :=
   case Zero()  => Zero()
   case Succ(x) => y.PlusFun( x.MultFun(y))
 
-consumer function Even:EPlus(y : Nat) : Nat :=
+cfun Even:EPlus(y : Nat) : Nat :=
   case EZero()  => y
   case ESucc(x) => Succ(Succ(x.EPlus(y)))
 
-consumer function Even:EMult(y : Nat) : Nat :=
+cfun Even:EMult(y : Nat) : Nat :=
   case EZero()  => Zero()
   case ESucc(x) => y.PlusFun(y.PlusFun(x.EMult(y)))
 
-consumer function Nat2Nat:Apply(y : Nat) : Nat :=
+cfun Nat2Nat:Apply(y : Nat) : Nat :=
   case Plus(x) => y.PlusFun(x)
   case Mult(x) => y.MultFun(x)
 
-consumer function Nat2Nat:EApply(y : Even) : Nat :=
+cfun Nat2Nat:EApply(y : Even) : Nat :=
   case Plus(x) => y.EPlus(x)
   case Mult(x) => y.EMult(x)

--- a/Repl/examples/interp.ub
+++ b/Repl/examples/interp.ub
@@ -2,7 +2,7 @@ data Nat where
    Zero()
    Succ(Nat)
 
-consumer function Nat:Sub(m: Nat) : Nat :=
+cfun Nat:Sub(m: Nat) : Nat :=
   case Zero() => Zero()
   case Succ(n) => 
      match Nat:Aux m using n1 := n : Nat returning Nat with
@@ -19,31 +19,31 @@ codata Env where
 codata Exp where
   Eval(Env) : Val
 
-generator function Cons(v: Val, env: Env) : Env :=
+gfun Cons(v: Val, env: Env) : Env :=
   cocase Index(i) => 
     match Nat:Lookup i using v1 := v : Val, e := env : Env returning Val with
        case Zero() => v1
        case Succ(n) => e.Index(n) 
        
-generator function Nil() : Env :=
+gfun Nil() : Env :=
   cocase Index(i) => Nil().Index(i)
          
-generator function Var(n: Nat) : Exp :=
+gfun Var(n: Nat) : Exp :=
   cocase Eval(env) => env.Index(n)
   
-generator function App(f: Exp, a: Exp) : Exp :=
+gfun App(f: Exp, a: Exp) : Exp :=
   cocase Eval(env) => f.Eval(env).Apply(a.Eval(env))  
   
-generator function Fun(body: Exp): Exp :=
+gfun Fun(body: Exp): Exp :=
   cocase Eval(env) => 
      comatch Val:Closure using b := body : Exp, en := env : Env with
         cocase Apply(arg) => b.Eval(Cons(arg,en))  
         cocase Reify(lvl) => Fun(b.Eval(Cons(ResVar(Succ(lvl)),en)).Reify(Succ(lvl)))
         
-generator function ResVar(n: Nat) : Val :=
+gfun ResVar(n: Nat) : Val :=
   cocase Apply(arg) => ResApp(ResVar(n),arg)
   cocase Reify(lvl) => Var(lvl.Sub(n))
   
-generator function ResApp(v1: Val, v2: Val) : Val := 
+gfun ResApp(v1: Val, v2: Val) : Val := 
   cocase Apply(v3) => ResApp(ResApp(v1,v2),v3)
   cocase Reify(lvl) => App(v1.Reify(lvl),v2.Reify(lvl))  

--- a/Repl/examples/natprog.ub
+++ b/Repl/examples/natprog.ub
@@ -9,15 +9,15 @@ codata NatStream where
    Current() : Nat
    Next() : NatStream
 
-function three() : Nat :=
+fun three() : Nat :=
    3
    
-function constStream(x : Nat) : NatStream :=
+fun constStream(x : Nat) : NatStream :=
    comatch NatStream:ConstStream using y := x : Nat with
       cocase Current() => y
       cocase Next() => constStream(y)
 
-function addStreamsStrict(x : NatStream , y : NatStream) : NatStream :=
+fun addStreamsStrict(x : NatStream , y : NatStream) : NatStream :=
    let z := y.Current() 
    in let v := x.Current() 
       in let w := y.Next() 
@@ -26,41 +26,41 @@ function addStreamsStrict(x : NatStream , y : NatStream) : NatStream :=
                   cocase Current() => x5.Plus(x4)
                   cocase Next() => addStreamsStrict(x3 , x2)
 
-function omega() : Nat :=
+fun omega() : Nat :=
    omega()
 
-consumer function Nat:Plus(x : Nat) : Nat :=
+cfun Nat:Plus(x : Nat) : Nat :=
    case Zero() => x
    case Succ(y) => Succ(y.Plus(x))
 
-consumer function Nat:GetAtIndex(x : NatStream) : Nat :=
+cfun Nat:GetAtIndex(x : NatStream) : Nat :=
    case Zero() => x.Current()
    case Succ(y) => y.GetAtIndex(x.Next())
 
-consumer function Nat:OmegaMatch() : Nat :=
+cfun Nat:OmegaMatch() : Nat :=
    case Zero() => 0
    case Succ(x) => Succ(x).OmegaMatch()
 
-generator function AddToStream(x : NatStream , y : Nat) : NatStream :=
+gfun AddToStream(x : NatStream , y : Nat) : NatStream :=
    cocase Current() => y.Plus(x.Current())
    cocase Next() => AddToStream(x.Next() , y)
    
-generator function Ascending() : NatStream :=
+gfun Ascending() : NatStream :=
    cocase Current() => 0
    cocase Next() => AddToStream(Ascending() , 1)
    
-generator function AddStreams(y : NatStream , x : NatStream) : NatStream :=
+gfun AddStreams(y : NatStream , x : NatStream) : NatStream :=
    cocase Current() => y.Current().Plus(x.Current())
    cocase Next() => AddStreams(y.Next() , x.Next())
    
-generator function OmegaComatch() : NatStream :=
+gfun OmegaComatch() : NatStream :=
    cocase Current() => 0
    cocase Next() => OmegaComatch().Next()
    
-generator function Fibonacci() : NatStream :=
+gfun Fibonacci() : NatStream :=
    cocase Current() => 0
    cocase Next() => ShiftedFib()
    
-generator function ShiftedFib() : NatStream :=
+gfun ShiftedFib() : NatStream :=
    cocase Current() => 1
    cocase Next() => AddStreams(Fibonacci() , ShiftedFib())

--- a/Repl/examples/natprog_nested.ub
+++ b/Repl/examples/natprog_nested.ub
@@ -9,14 +9,14 @@ codata NatStream where
    Current() : Nat
    Next() : NatStream
 
-function three() : Nat :=
+fun three() : Nat :=
     3
-function constStream(x : Nat) : NatStream :=
+fun constStream(x : Nat) : NatStream :=
     comatch NatStream:ConstStream using y := x : Nat with
        cocase Current() => y
        cocase Next() => constStream(y)
 
-function addStreamsStrict(x : NatStream , y : NatStream) : NatStream :=
+fun addStreamsStrict(x : NatStream , y : NatStream) : NatStream :=
     let z := y.Current() 
     in let v := x.Current() 
        in let w := y.Next() 
@@ -25,58 +25,58 @@ function addStreamsStrict(x : NatStream , y : NatStream) : NatStream :=
                    cocase Current() => x5.Plus(x4)
                    cocase Next() => addStreamsStrict(x3 , x2)
 
-function omega() : Nat :=
+fun omega() : Nat :=
     omega()
 
 
-function isEven(x : Nat) : Bool :=
+fun isEven(x : Nat) : Bool :=
     match Nat:Even x returning Bool with
       case Zero() => True()
       case Succ(y) => match Nat:Odd y returning Bool with
                         case Zero() => False()
                         case Succ(z) => isEven(z)
 
-consumer function Bool:And(x : Bool) : Bool :=
+cfun Bool:And(x : Bool) : Bool :=
     case True() => x
     case False() => False()
 
-consumer function Nat:Plus(x : Nat) : Nat :=
+cfun Nat:Plus(x : Nat) : Nat :=
     case Zero() => x
     case Succ(y) => Succ(y.Plus(x))
     
-consumer function Nat:GetAtIndex(x : NatStream) : Nat :=
+cfun Nat:GetAtIndex(x : NatStream) : Nat :=
     case Zero() => x.Current()
     case Succ(y) => y.GetAtIndex(x.Next())
     
-consumer function Nat:OmegaMatch() : Nat :=
+cfun Nat:OmegaMatch() : Nat :=
     case Zero() => 0
     case Succ(x) => Succ(x).OmegaMatch()
 
-generator function AddToStream(x : NatStream , y : Nat) : NatStream :=
+gfun AddToStream(x : NatStream , y : Nat) : NatStream :=
    cocase Current() => y.Plus(x.Current())
    cocase Next() => AddToStream(x.Next() , y)
    
-//generator function Ascending() : NatStream :=
+//gfun Ascending() : NatStream :=
 //   cocase Current() => 0
 //   cocase Next() => addToStream(Ascending() , 1)
    
-generator function AddStreams(y : NatStream , x : NatStream) : NatStream :=
+gfun AddStreams(y : NatStream , x : NatStream) : NatStream :=
    cocase Current() => y.Current().Plus(x.Current())
    cocase Next() => AddStreams(y.Next() , x.Next())
    
-generator function OmegaComatch() : NatStream :=
+gfun OmegaComatch() : NatStream :=
    cocase Current() => 0
    cocase Next() => OmegaComatch().Next()
    
-generator function Fibonacci() : NatStream :=
+gfun Fibonacci() : NatStream :=
    cocase Current() => 0
    cocase Next() => ShiftedFib()
    
-generator function ShiftedFib() : NatStream :=
+gfun ShiftedFib() : NatStream :=
    cocase Current() => 1
    cocase Next() => AddStreams(Fibonacci() , ShiftedFib())
 
-function isZero(x : Nat) : Bool :=
+fun isZero(x : Nat) : Bool :=
   match Nat:IsZero x returning Bool with
     case Zero() => True()
     case Succ(y) => False()

--- a/Repl/examples/parserexample.ub
+++ b/Repl/examples/parserexample.ub
@@ -13,7 +13,7 @@ data Nat where
   Zero()
   Succ(Nat)
 
-function testSuccZero() : Nat :=
+fun testSuccZero() : Nat :=
   Succ(Zero())
   
 data Test1 where
@@ -24,37 +24,37 @@ codata Test2 where
   Destr1(Nat, NatStream, Nat, Nat) : Bool
   Destr2(Nat, Nat, Nat, Nat) : Nat
 
-function test4() : Nat :=
+fun test4() : Nat :=
   4
 
-function testx(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
+fun testx(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
   x
 
-function testy(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
+fun testy(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
   y
 
-function testz(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
+fun testz(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
   z
 
-function testv(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
+fun testv(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
   v
 
-function testw(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
+fun testw(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
   w
 
-function testLetFooInFoo(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
+fun testLetFooInFoo(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
   let foo := x
   in foo
 
-function testLetFooInZ(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
+fun testLetFooInZ(x : Bool, y : Bool, z : Bool, v : Bool, w : Bool) : Bool :=
   let foo := x
   in z
 
-generator function Ascending(x : Nat) : Test2 :=
+gfun Ascending(x : Nat) : Test2 :=
   cocase Destr1(y,z,v,w) => True()
   cocase Destr2(y,z,v,w) => x
 
-consumer function Test1:Mycfun(x : Bool) : Nat :=
+cfun Test1:Mycfun(x : Bool) : Nat :=
   case Constr1(y, z, v, w) => y
   case Constr2(y, z, v, w) => z
 

--- a/Repl/examples/simple_nested.ub
+++ b/Repl/examples/simple_nested.ub
@@ -8,27 +8,27 @@ data Stream where
   _L2()
   _L3()
 
-/* consumer function Stream:D1(()) : Bool := */
+/* cfun Stream:D1(()) : Bool := */
   /* case Simpl() => False() */
   /* case _L1() => True() */
   /* case _L2() => False() */
   /* case _L3() => False() */
-/* consumer function Stream:D2(()) : Bool := */
+/* cfun Stream:D2(()) : Bool := */
   /* case Simpl() => False() */
   /* case _L1() => False() */
   /* case _L2() => True() */
   /* case _L3() => False() */
-/* consumer function Stream:D3(()) : Bool := */
+/* cfun Stream:D3(()) : Bool := */
   /* case Simpl() => False() */
   /* case _L1() => False() */
   /* case _L2() => False() */
   /* case _L3() => True() */
-consumer function Stream:S() : Stream :=
+cfun Stream:S() : Stream :=
   case Simpl() => Simpl()
   case _L1() => _L3()
   case _L2() => _L1()
   case _L3() => Simpl()
-consumer function Stream:S2() : Stream :=
+cfun Stream:S2() : Stream :=
   case Simpl() => _L2()
   case _L1() => Simpl()
   case _L2() => Simpl()

--- a/Repl/examples/trafficlights.ub
+++ b/Repl/examples/trafficlights.ub
@@ -15,25 +15,25 @@ codata TrafficLight where
   Color() : Color
   Switch() : TrafficLight
 
-function ifThenElse(b : Bool, t : TrafficLight, e : TrafficLight) : TrafficLight :=
+fun ifThenElse(b : Bool, t : TrafficLight, e : TrafficLight) : TrafficLight :=
   match Bool:Ite b using x := t : TrafficLight , y := e : TrafficLight returning TrafficLight with
     case True() => x
     case False() => y
 
-consumer function Nat:NthColor(tl : TrafficLight) : Color :=
+cfun Nat:NthColor(tl : TrafficLight) : Color :=
   case Zero() => tl.Color()
   case Succ(y) => let next := tl.Switch()
                   in y.NthColor(next)
 
-consumer function Nat:Plus(x : Nat) : Nat :=
+cfun Nat:Plus(x : Nat) : Nat :=
   case Zero() => x
   case Succ(y) => Succ(y.Plus(x))
 
-generator function ConstRed() : TrafficLight :=
+gfun ConstRed() : TrafficLight :=
   cocase Color() => Red()
   cocase Switch() => ConstRed()
 
-generator function RedLight() : TrafficLight :=
+gfun RedLight() : TrafficLight :=
   cocase Color() => Red()
   cocase Switch() => comatch TrafficLight:GreenLight with
                          cocase Color() => Green()

--- a/Repl/src/Parser/Declarations.hs
+++ b/Repl/src/Parser/Declarations.hs
@@ -156,7 +156,7 @@ functionDeclP = L.nonIndented scn (L.indentBlock scn parse)
 -- | Parse the declaration of a function.
 functionDeclSigP :: Parser (FNameParse, [(VarNameParse, TypeNameParse)], TypeNameParse) 
 functionDeclSigP = do
-  try (rword "function")
+  try (rword "fun")
   fname <- fnameP
   fargs <- parens parseArgs
   _ <- symbol ":"
@@ -191,7 +191,7 @@ generatorFunctionDeclP = L.nonIndented scn (L.indentBlock scn parse)
 -- | Parse the declaration of a generator function.
 generatorFunctionDeclSigP :: Parser (QName, [(VarNameParse, TypeNameParse)])
 generatorFunctionDeclSigP = do
-  try (rword "generator function")
+  try (rword "gfun")
   fname <- uppercaseIdentP
   fargs <- parens parseArgs
   _ <- symbol ":"
@@ -227,7 +227,7 @@ consumerFunctionDeclP = L.nonIndented scn (L.indentBlock scn parse)
 -- Returns the Signature of the consumer function and a list of the names of the bound variables.
 consumerFunctionDeclSigP :: Parser (QName, [(VarNameParse, TypeNameParse)], TypeNameParse)
 consumerFunctionDeclSigP = do
-  try (rword "consumer function")
+  try (rword "cfun")
   qn <- do
     tn <- uppercaseIdentP
     _ <- symbol ":"

--- a/Repl/src/Parser/Lexer.hs
+++ b/Repl/src/Parser/Lexer.hs
@@ -58,8 +58,8 @@ parens = between (symbol "(") (symbol ")")
 
 -- | A list of reserved keywords
 rws :: [String]
-rws = ["data", "codata", "where", "in", "let", "match", "comatch", "function",
-       "case", "cocase", "generator", "consumer", "using", "with", "returning"]
+rws = ["data", "codata", "where", "in", "let", "match", "comatch", "fun",
+       "case", "cocase", "gfun", "cfun", "using", "with", "returning"]
 
 -- | Parse a reserved keyword.
 -- The parsed keyword mustn't be the prefix of an identifier.

--- a/Repl/src/Prettyprinter/Declarations.hs
+++ b/Repl/src/Prettyprinter/Declarations.hs
@@ -60,7 +60,7 @@ functionDeclarationToDoc fname argts rtype body = do
   ppbody <- exprToDoc body
   ppargs <- argumentListToDoc argts
   return $
-    keyword "function" <+> pretty fname <> ppargs <+> colon <+> typename rtype <+> pretty ":=" <>
+    keyword "fun" <+> pretty fname <> ppargs <+> colon <+> typename rtype <+> pretty ":=" <>
     (nest 3 (line <> ppbody))
 
 -- | Prettyprint all function declarations.
@@ -134,7 +134,7 @@ consumerFunctionDeclarationToDoc qn argts rtype cases = do
   ppcases <- sequence (caseToDoc <$> cases)
   ppargs <- argumentListToDoc argts
   return $
-    keyword "consumer function" <+>
+    keyword "cfun" <+>
     typename (fst qn) <> pretty ":" <> pretty (snd qn) <>
     ppargs <+> colon <+> typename rtype <+> pretty ":=" <>
     (nest 3 (line <> (vcat ppcases)))
@@ -203,7 +203,7 @@ generatorFunctionDeclarationToDoc qn argts cocases = do
   ppargs <- argumentListToDoc argts
   ppqn <- qNameToDoc qn
   return $
-    keyword "generator function" <+> ppqn <> ppargs <+> colon <+> typename (fst qn) <+> pretty ":=" <>
+    keyword "gfun" <+> ppqn <> ppargs <+> colon <+> typename (fst qn) <+> pretty ":=" <>
     (nest 3 (line <> (vcat ppcocases)))
 
 -- | Prettyprint all generator function declarations.


### PR DESCRIPTION
Changes the surface syntax in the
- Parser
- Prettyprinter
- examples/*.ub files

The following changes are implemented for toplevel functions:
- "generator function" >> "gfun"
- "consumer function" >>"cfun"
- "function" >>"fun"

This brings the syntax in the REPL to the same state as the syntax in the paper.